### PR TITLE
Install sqlite 3.31.1 in the jenkins container.

### DIFF
--- a/roles/jenkins/files/Dockerfile.dbdrivers
+++ b/roles/jenkins/files/Dockerfile.dbdrivers
@@ -37,7 +37,16 @@ RUN \
 	make && make install && \
 	cd ..
 
+ARG sqlite_release_year=2020
+ARG sqlite_release_number=3310100
 
+RUN \
+	curl -L -O https://www.sqlite.org/${sqlite_release_year}/sqlite-autoconf-${sqlite_release_number}.tar.gz && \
+	tar -xf sqlite-autoconf-${sqlite_release_number}.tar.gz && \
+	cd sqlite-autoconf-${sqlite_release_number} && \
+	./configure --prefix /opt/sqlite3 && \
+	make && make install && \
+	cd ..
 
 # install SQL Server client stuff
 ENV ACCEPT_EULA="Y"


### PR DESCRIPTION
It can be used by setting `LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/sqlite3/lib /path/to/python`

I'm not sure where I should update the ci jobs to use this sqlite version